### PR TITLE
Update esp-web-tools

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn index() -> content::RawHtml<&'static str> {
                 <div id=\"main\" style=\"display: none;\">
 
                     <br>
-                    <script type=\"module\" src=\"https://unpkg.com/esp-web-tools@8.0.2/dist/web/install-button.js?module\">
+                    <script type=\"module\" src=\"https://unpkg.com/esp-web-tools/dist/web/install-button.js?module\">
                     </script>
                     <esp-web-install-button id=\"installButton\" manifest=\"manifest.json\"></esp-web-install-button>
                     <br>

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn index() -> content::RawHtml<&'static str> {
                 <div id=\"main\" style=\"display: none;\">
 
                     <br>
-                    <script type=\"module\" src=\"https://unpkg.com/esp-web-tools/dist/web/install-button.js?module\">
+                    <script type=\"module\" src=\"https://unpkg.com/esp-web-tools@9.4.3/dist/web/install-button.js?module\">
                     </script>
                     <esp-web-install-button id=\"installButton\" manifest=\"manifest.json\"></esp-web-install-button>
                     <br>


### PR DESCRIPTION
Esp32-c3: old version throwing an error. Solved updating esp-web-tools.

Working artifacts at https://github.com/lorenzodellagiustina/esp-web-flash-server/releases/latest/download/web-flash-${ARCH}.zip